### PR TITLE
Upgrade - Goss 0.3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Read more about Goss at https://goss.rocks/.
 
 ### `version`
 
-**Optional** The required version of Goss to install. Default `"v0.3.13"`.
+**Optional** The required version of Goss to install. Default `"v0.3.14"`.
 
 ## Example usage
 
 ```yml
 uses: e1himself/goss-installation-action
 with:
-  version: 'v0.3.13'
+  version: 'v0.3.14'
 ```

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Read more about Goss at https://goss.rocks/.
 ```yml
 uses: e1himself/goss-installation-action
 with:
-  version: 'v0.3.9'
+  version: 'v0.3.13'
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core'
 import * as tc from '@actions/tool-cache'
 
 const ARCH = 'amd64'
-const DEFAULT_VERSION = 'v0.3.13'
+const DEFAULT_VERSION = 'v0.3.14'
 
 interface CommandsMap {
   [command: string]: string


### PR DESCRIPTION
- Bump default Goss version to `v0.3.14`